### PR TITLE
Fix playing old videos when configured quality is not available

### DIFF
--- a/plugin.video.giantbomb/default.py
+++ b/plugin.video.giantbomb/default.py
@@ -376,7 +376,8 @@ def play_video(video_id):
         quality_mapping = ['low_url', 'high_url', 'hd_url']
         quality = quality_mapping[ int(my_addon.getSetting('video_quality')) ]
 
-        video_url = (video.get(quality, video['high_url']) +
+        video_url = ((video.get(quality) or video.get('hd_url') or
+                      video.get('high_url') or video.get('low_url')) +
                      '?api_key=' + gb.api_key)
         li = xbmcgui.ListItem(path=video_url)
         xbmcplugin.setResolvedUrl(addon_id, True, li)


### PR DESCRIPTION
I've been noticing some unplayable videos lately. Digging in showed that the GiantBomb API now includes empty dictionary key/value pairs for qualities that are unavailable, breaking the original play_video method since it was trying to use None as the video url.

I figure if the configured quality is unavailable, let's traverse down the list and find the best quality that is available.